### PR TITLE
[IN-887] Stop sending test coverage to Code Climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  go: achievementnetwork/go@2.8.1
+  go: achievementnetwork/go@3.0.0
 
 workflows:
   version: 2


### PR DESCRIPTION
* Update to the latest Orb versions that no longer send test coverage to Code Climate
* Remove the Code Climate test reporter id from the CircleCI config
